### PR TITLE
Allow for running portions of pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,20 @@ dump.rdb
 gql/*/*
 extracted/*
 .dlt/*
+
 sql_database_pipeline.py
 api_responses/*
 tests/jobs_voyagerJobsDashJobCards.json
 linkedin.duckdb
+.envrc
+*information.js
+# Old files
+linkedin_old.duckdb
+rest_scraper_old.py
+li_scraper/*
+*.csv
+node_modules/*
+
+*.duckdb
+package-lock.json
+gql/profile_gql_queries.json

--- a/saved_queries.py
+++ b/saved_queries.py
@@ -1,22 +1,25 @@
 import duckdb
 
-db = duckdb.connect("linkedin.duckdb")
-
 
 
 # @dlt.resource
-def db_followed_companies():
-    db = duckdb.connect("linkedin.duckdb") 
-    followed_companies = db.sql("select * from linkedin_data.followed_companies")
+def db_followed_companies(db_path):
+    db = duckdb.connect(db_path) 
+    followed_companies = db.sql("select * from linkedin_data.followed_companies" )
     return followed_companies.df().to_dict(orient='records')
 
-def get_finished_jobs():
-    db = duckdb.connect("linkedin.duckdb") 
+def db_job_urls(db_path):
+    db = duckdb.connect(db_path) 
+    job_urls = db.sql("select * from linkedin_data.job_urls")
+    return job_urls.df().to_dict(orient='records')
+
+def get_finished_jobs(db_path):
+    db = duckdb.connect(db_path) 
     job_descs = db.sql("select job_posting_urn from linkedin_data.job_description")
     return job_descs.df()['job_posting_urn'].to_list()
 
-def identified_jobs():
-    db = duckdb.connect("linkedin.duckdb") 
+def identified_jobs(db_path):
+    db = duckdb.connect(db_path) 
     followed_companies = db.sql("select job_posting_title from linkedin_data.jobs_by_company")
     return followed_companies.df()['job_id'].to_list()
 
@@ -37,13 +40,14 @@ def delete_not_followed_company_jobs():
             Where company_name is null
             )""")
     
-def get_jobs_filtered(filter_str = "'Data' in job_posting_title" ):
-    db = duckdb.connect("linkedin.duckdb")
+def get_jobs_filtered(db_path, filter_str = "'Data' in job_posting_title" ):
+    db = duckdb.connect(db_path)
     jobs = db.sql("""
         select distinct a.job_posting_title, 
                         b.company_name, 
                         a.job_posting_urn,
                         c.description
+                        a.location,
         from (
                 Select job_posting_urn, 
                         LOWER(job_posting_title) as job_posting_title, 
@@ -53,27 +57,114 @@ def get_jobs_filtered(filter_str = "'Data' in job_posting_title" ):
                 SELECT name as company_name, company_id 
                 FROM linkedin_data.followed_companies) as b 
             on a._followed_companies_company_id=b.company_id
-            left join (
-                SELECT job_posting_urn, description_text as description
-                FROM linkedin_data.job_description) as c 
-            on a.job_posting_urn=c.job_posting_urn""")
+            """)
+    # left join (
+    #             SELECT job_posting_urn, description_text as description
+    #             FROM linkedin_data.job_description) as c 
+    #         on a.job_posting_urn=c.job_posting_urn
     data_jobs = jobs.filter(filter_str)
     return data_jobs.df()
     
-def get_data_jobs():
-    filter_str = """'data engineer' in job_posting_title
+def get_data_jobs(db_path):
+    filter_str = """('data engineer' in job_posting_title
                     OR 'data scientist' in job_posting_title
                     OR 'scientific programmer' in job_posting_title
                     OR 'python' in job_posting_title
-                    OR 'data' in job_posting_title
+                    OR 'data' in job_posting_title)
+                    AND 'manager' not in job_posting_title
+                    AND 'analyst' not in job_posting_title
+                    AND 'director' not in job_posting_title
+                    AND 'head' not in job_posting_title
+                    AND 'visualization' not in job_posting_title
+                    AND 'Jobot' not in company_name
                     """
-    return get_jobs_filtered(filter_str)
+    return get_jobs_filtered(db_path, filter_str)
 
-def get_software_jobs():
+def get_rs_jobs(db_path):
+    filter_str = """('lidar' in lower(job_posting_title)
+                    OR 'lidar' in lower(job_posting_title)
+                     OR 'geospatial' in lower(job_posting_title)
+                     OR 'remote sensing' in lower(job_posting_title)
+                    )
+                    """
+    test = get_jobs_filtered(db_path, filter_str)
+    breakpoint()
+    return test
+
+def get_software_jobs(db_path):
     filter_str = """'software engineer' in job_posting_title
                     OR 'software developer' in job_posting_title
                     OR 'software' in job_posting_title
                     OR 'developer' in job_posting_title
                     OR 'developer' in job_posting_title
                     """
-    return get_jobs_filtered(filter_str)
+    return get_jobs_filtered(db_path, filter_str)
+
+def jobs_by_company(db_path):
+    db = duckdb.connect(db_path) 
+    followed_companies = db.sql("select * from linkedin_data.jobs_by_company")
+    return followed_companies.df()
+
+def get_job_urls(db_path):
+    # jobs = get_rs_jobs()
+    filter_str = """1=1"""
+    jobs = get_jobs_filtered(db_path, filter_str)
+    # jobs = get_rs_jobs(db_path)
+
+    # remote_jobs = jobs[jobs['location'].str.contains('Remote')]
+    jobs['job_id'] = jobs['job_posting_urn'].str.replace('urn:li:fsd_jobPosting:','')
+    jobs['job_urls'] = 'https://www.linkedin.com/jobs/view/' + jobs['job_id']
+    job_urls = [(x, y) for x, y in zip(jobs['job_urls'], jobs['company_name'].to_list())]
+    jobs.to_csv('all_jobs_20250803.csv', index=False)
+    # jobs_not_to_push = ['https://www.linkedin.com/jobs/view/4257497407/']
+
+    # # breakpoint()
+    # db = duckdb.connect("linkedin.duckdb") 
+    # res = db.sql("SELECT url FROM linkedin_data.job_urls").df().to_list()
+
+    followed_companies = db_followed_companies(db_path)
+    # db.sql("DROP TABLE linkedin_data.job_urls")
+    # db.sql("CREATE TABLE linkedin_data.job_urls (url TEXT, company_name TEXT)")
+
+    # res = db.executemany("INSERT INTO linkedin_data.job_urls (url, company_name) VALUES (?, ?)", job_urls)
+
+    return followed_companies
+
+def get_column_info(col):
+    info = f'{col} TEXT'
+    if '_dlt' in col:
+        info = f'{col} TEXT NOT NULL'
+    return info
+
+
+def generate_insert_query(columns):
+    return f"INSERT INTO linkedin_data.followed_companies ({', '.join(columns)}) VALUES ({', '.join([f'?' for _ in columns])})"
+
+def populate_new_company_db(new_db_path, old_db_path):  
+    company_data = db_followed_companies(old_db_path)
+    columns =  ['name', '_type', '_recipe_type', 'entity_urn', 'url', 'company_id', '_dlt_load_id', '_dlt_id']
+    to_insert = [[row[col] for col in columns] for row in company_data]
+
+    # create schema if not exists
+    db = duckdb.connect(new_db_path)
+    db.sql("CREATE SCHEMA IF NOT EXISTS linkedin_data")
+    db.sql(f"CREATE OR REPLACE TABLE linkedin_data.followed_companies ({', '.join([get_column_info(c) for c in columns])})")
+    
+    expected_insert_query = "INSERT INTO linkedin_data.followed_companies (name, _type, _recipe_type, entity_urn, url, company_id) VALUES (?, ?, ?, ?, ?, ?)"
+    insert_query = generate_insert_query(columns)
+    # assert insert_query == expected_insert_query
+    breakpoint()
+    db.executemany(insert_query, to_insert)
+
+    # old_db_path = "linkedin_1.duckdb"
+    # new_db_path = "linkedin.duckdb"
+    # populate_new_company_db(new_db_path, old_db_path)
+
+if __name__ == "__main__":
+    # old_db_path = "linkedin_1.duckdb"
+    new_db_path = "linkedin.duckdb"
+    # populate_new_company_db(new_db_path, old_db_path)
+    # urls = db_job_urls(new_db_path)
+
+    get_job_urls(new_db_path)
+    breakpoint()

--- a/voyager_client.py
+++ b/voyager_client.py
@@ -32,6 +32,7 @@ class CustomAuth():
         self.session.proxies.update(proxies)
         self.session.headers.update(REQUEST_HEADERS)
         self._use_cookie_cache = use_cookie_cache
+        self.status = None
 
     ## TODO: expand caching with hset/hgetall
     def get_cached_cookies(self, url: str):
@@ -88,10 +89,10 @@ class CustomAuth():
 
     def authenticate(self):
         if self._use_cookie_cache:
-            self.logger.debug("Attempting to use cached cookies")
+            self.logger.info("Attempting to use cached cookies")
             cookies = self.get_cached_cookies(self.username)
             if cookies:
-                self.logger.debug("Using cached cookies")
+                self.logger.info("Using cached cookies")
                 self._set_session_cookies(cookies)
                 return
 
@@ -147,10 +148,12 @@ class CustomAuth():
                             and log back in on your browser. You may also need 
                             to delete all listed "Devices that remember your password"
                              under Sign in & security.''')
+            self.status = res.status_code
             raise res.raise_for_status()
 
         if res.status_code != 200:
             logger.error('unknown exception while authenticating')
+            self.status = res.status_code
             raise res.raise_for_status()
 
         self._set_session_cookies(res.cookies)


### PR DESCRIPTION
Updating the dlt linkedin source to flex included resources based on inputs. Mostly this is to be used to avoid having to repull followed companies when looking for new postings.